### PR TITLE
fix: allow to change rustls crypto provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,10 @@ exclude = [
 ]
 
 [features]
-default = []
+default = ["rustls-aws-lc-rs"]
 turmoil-testing = ["turmoil"]
+rustls-aws-lc-rs = ["rustls/aws-lc-rs", "tokio-rustls/aws-lc-rs"]
+rustls-ring = ["rustls/ring", "tokio-rustls/ring"]
 
 [dev-dependencies]
 tokio-test = "0.4"
@@ -102,14 +104,14 @@ futures-util = "0.3.31"
 hex = "0.4.3"
 humantime-serde = "1.1"
 rand = "0.9.2"
-rustls = "0.23.29"
+rustls = { version = "0.23.29", default-features = false, features = ["log", "std"] }
 rustls-pemfile = "2.2.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
 sha2 = "0.10.8"
 thiserror = "2.0.12"
 tokio = { version = "1.47.1", features = ["full"] }
-tokio-rustls = "0.26.2"
+tokio-rustls = { version = "0.26.2", default-features = false, features = ["logging", "tls12"] }
 tokio-tungstenite = "0.27.0"
 toml = "0.9.4"
 tracing = "0.1.41"


### PR DESCRIPTION
Hi!

I'm building a project where I have to cross compile to ARMv6.
Because the dependencies to `rustls` and `tokio-rustls` use default features, this brings `aws-lc-sys` which fails to compile on this target.

So I made some changes to introduce two features (`rustls-aws-lc-rs` and `rustls-ring`) which allow to chose the crypto provider for Rustls.
`rustls-aws-lc-rs` is enabled by default so that nothing should break (as it is the current behavior) and one can choose to disable it and enable `rustls-ring` if needed.